### PR TITLE
Handle extension port errors and initialize dashboard

### DIFF
--- a/js/analytics-dashboard.js
+++ b/js/analytics-dashboard.js
@@ -9,6 +9,7 @@ class AnalyticsDashboard {
         this.analyticsData = null;
         this.processedStats = null;
         this.isInitialized = false;
+        this._containerId = null;
         
         this.init();
     }
@@ -54,7 +55,11 @@ class AnalyticsDashboard {
             
             if (window.AnalyticsAPI) {
                 this.analyticsData = await window.AnalyticsAPI.getAnalyticsData(timeRange);
-                this.processedStats = window.AnalyticsAPI.processAnalyticsData(this.analyticsData);
+                if (window.AnalyticsAPI.processAnalyticsData && typeof window.AnalyticsAPI.processAnalyticsData === 'function') {
+                    this.processedStats = window.AnalyticsAPI.processAnalyticsData(this.analyticsData);
+                } else {
+                    this.processedStats = this.processData(this.analyticsData);
+                }
             } else {
                 // Fallback: Direkt aus Firebase laden
                 this.analyticsData = await this.loadDataFromFirebase(timeRange);
@@ -394,7 +399,7 @@ class AnalyticsDashboard {
         if (timeRangeSelect) {
             timeRangeSelect.addEventListener('change', async (e) => {
                 await this.loadAnalyticsData(e.target.value);
-                this.renderDashboard('analytics-tab');
+                this.renderDashboard(this._containerId || 'analytics-content');
             });
         }
         
@@ -403,7 +408,7 @@ class AnalyticsDashboard {
         if (refreshBtn) {
             refreshBtn.addEventListener('click', async () => {
                 await this.loadAnalyticsData(this.currentTimeRange);
-                this.renderDashboard('analytics-tab');
+                this.renderDashboard(this._containerId || 'analytics-content');
             });
         }
         
@@ -446,6 +451,7 @@ class AnalyticsDashboard {
     // Dashboard initialisieren
     async initializeDashboard(containerId) {
         try {
+            this._containerId = containerId;
             await this.loadAnalyticsData(this.currentTimeRange);
             this.renderDashboard(containerId);
         } catch (error) {
@@ -471,5 +477,6 @@ window.analyticsDashboard = new AnalyticsDashboard();
 window.AnalyticsDashboardAPI = {
     loadAnalyticsData: (timeRange) => window.analyticsDashboard.loadAnalyticsData(timeRange),
     renderDashboard: (containerId) => window.analyticsDashboard.renderDashboard(containerId),
-    initializeDashboard: (containerId) => window.analyticsDashboard.initializeDashboard(containerId)
+    initializeDashboard: (containerId) => window.analyticsDashboard.initializeDashboard(containerId),
+    exportAnalyticsData: () => window.analyticsDashboard.exportAnalyticsData()
 };


### PR DESCRIPTION
Implement fallback for missing `AnalyticsAPI.processAnalyticsData`, fix dashboard re-render container, and expose analytics export function to resolve dashboard initialization errors and improve functionality.

The `TypeError: window.AnalyticsAPI.processAnalyticsData is not a function` occurred because the external `processAnalyticsData` was sometimes unavailable, causing dashboard initialization to fail. Persisting the `containerId` ensures that dashboard updates (e.g., after changing time ranges) correctly target the original container, preventing rendering issues. Exposing `exportAnalyticsData` provides a necessary utility for users to extract data.

---
<a href="https://cursor.com/background-agent?bcId=bc-168f39e3-cb5f-4b29-bbb7-3deeb3a4cb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-168f39e3-cb5f-4b29-bbb7-3deeb3a4cb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

